### PR TITLE
fix: prevent NullPointerException in BaseBrowserFragment when opening new tabs

### DIFF
--- a/app/src/main/java/com/prirai/android/nira/BaseBrowserFragment.kt
+++ b/app/src/main/java/com/prirai/android/nira/BaseBrowserFragment.kt
@@ -652,6 +652,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
 
     @VisibleForTesting
     internal fun initializeEngineView(toolbarHeight: Int) {
+        // Return if fragment is detached or binding is null
+        if (context == null) return
+        if (_binding == null) return
+
         val context = requireContext()
         val prefs = UserPreferences(context)
 
@@ -661,6 +665,9 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         // Get actual toolbar height (may differ from parameter if components are hidden)
         // Use post to ensure toolbar is measured
         unifiedToolbar?.post {
+            // Guard: view may have been destroyed while this was queued
+            if (_binding == null) return@post
+
             val actualToolbarHeight = unifiedToolbar?.height ?: toolbarHeight
             
             // Set padding on swipeRefresh to prevent content from appearing under toolbar


### PR DESCRIPTION
## Description
Fixed a crash that happened when opening new tabs on my Pixel 7 running Android 16. The app would randomly crash with a NullPointerException in BaseBrowserFragment.

## Root Cause
The initializeEngineView method uses unifiedToolbar?.post {} to defer UI work, but doesn't check if the fragment view is still valid when the callback executes. If the view gets destroyed before the callback executes, `_binding` is null and the app crashes.

The crash log showed: `NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference at BaseBrowserFragment.getBinding`

## Changes Made
Added null checks for `_binding` and `context` at the start of `initializeEngineView`, plus a guard inside the `post` lambda to prevent accessing the binding after the view is destroyed.

## Testing
Built debug APK and tested on my Pixel 7 (Android 16) for several minutes opening tabs rapidly, and emulating regular use. The crash no longer seems to happen.