### PR TITLE
Fix Firefox Accounts (FxA) sync — WebChannel OOB redirect URL + bookmark bridge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -200,6 +200,8 @@ dependencies {
     implementation "org.mozilla.components:lib-state:$mozComponentsVersion"
     implementation "org.mozilla.components:lib-publicsuffixlist:$mozComponentsVersion"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:$mozComponentsVersion"
+    implementation "org.mozilla.components:lib-dataprotect:$mozComponentsVersion"
+    implementation "org.mozilla.components:support-appservices:$mozComponentsVersion"
 
     implementation 'androidx.credentials:credentials:1.6.0'
     implementation 'androidx.credentials:credentials-play-services-auth:1.6.0'

--- a/app/src/main/java/com/prirai/android/nira/BrowserApp.kt
+++ b/app/src/main/java/com/prirai/android/nira/BrowserApp.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.support.base.facts.Facts
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.support.base.facts.processor.LogFactProcessor
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.isMainProcess
@@ -39,6 +40,28 @@ class BrowserApp : Application() {
         }
 
         Facts.registerProcessor(LogFactProcessor())
+
+        // CRITICAL: Load NSS native libraries so the Rust megazord can find
+        // them via dlopen(). The Rust fxaclient needs NSS for PKCE crypto.
+        try {
+            System.loadLibrary("mozglue");
+            System.loadLibrary("nss3");
+            System.loadLibrary("freebl3");
+            System.loadLibrary("softokn3");
+
+            // Initialize Rust component infrastructure (NSS, logging, etc.)
+            mozilla.components.support.AppServicesInitializer.init(
+                mozilla.components.support.AppServicesInitializer.Config(
+                    crashReporting = null,
+                    logLevel = mozilla.components.support.base.log.Log.Priority.DEBUG,
+                )
+            )
+            mozilla.components.support.rusthttp.RustHttpConfig.setClient(
+                lazy { mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient() }
+            )
+        } catch (e: Exception) {
+            android.util.Log.w("BrowserApp", "Rust/NSS init failed (sync may be unavailable)", e)
+        }
 
         // CRITICAL: Only warmUp the engine - don't trigger full initialization yet
         // This prepares GeckoView but doesn't block on heavy operations
@@ -71,18 +94,53 @@ class BrowserApp : Application() {
             initializeWebExtensions()
         }
         
+        // Install the FxA WebChannel extension for OOB redirect handling
+        applicationScope.launch(Dispatchers.Main) {
+            try {
+                components.engine.installBuiltInWebExtension(
+                    url = "resource://android/assets/extensions/fxawebchannel/",
+                    id = "fxa@mozac.org",
+                    onSuccess = { ext ->
+                        com.prirai.android.nira.browser.sync.FxaSyncManager.webChannelExtension = ext
+                    },
+                    onError = { err ->
+                        android.util.Log.e("FxaAuth", "FxA extension install FAILED", err)
+                    }
+                )
+            } catch (e: Exception) {
+                android.util.Log.e("FxaAuth", "FxA extension install exception", e)
+            }
+        }
+
         // CRITICAL: Eagerly init fxaAuthFeature on the Main thread so that
         // appRequestInterceptor.fxaInterceptor is set before any FxA redirect URL
         // can be processed. Doing this inside an IO coroutine causes a race condition
         // where the interceptor may not be ready when the OAuth callback arrives.
         try {
             components.fxaAuthFeature
+            logger.info("FxA auth feature initialized")
         } catch (_: Exception) { /* sync unavailable */ }
 
         // Initialize Firefox Sync (non-blocking — degrades gracefully if unavailable)
         applicationScope.launch(Dispatchers.IO) {
             try {
-                components.fxaSyncManager.initialize()
+                components.fxaSyncManager.start()
+                logger.info("FxA sync manager start() completed")
+            } catch (_: Exception) { /* sync unavailable */ }
+        }
+
+        // Collect incoming FxA tabs (e.g. Send Tab from another device)
+        applicationScope.launch(Dispatchers.Main) {
+            try {
+                components.fxaSyncManager.incomingTabs.collect { tabReceived ->
+                    val entries = tabReceived.entries
+                    entries.forEach { tab ->
+                        components.tabsUseCases.addTab(
+                            url = tab.url,
+                            selectTab = entries.size == 1,
+                        )
+                    }
+                }
             } catch (_: Exception) { /* sync unavailable */ }
         }
         

--- a/app/src/main/java/com/prirai/android/nira/browser/bookmark/ui/AddBookmarkDialog.kt
+++ b/app/src/main/java/com/prirai/android/nira/browser/bookmark/ui/AddBookmarkDialog.kt
@@ -1,5 +1,8 @@
 package com.prirai.android.nira.browser.bookmark.ui
 
+import com.prirai.android.nira.ext.components
+import kotlinx.coroutines.launch
+
 import android.content.Context
 import android.content.DialogInterface
 import android.text.TextUtils
@@ -128,7 +131,22 @@ abstract class AddBookmarkDialog<S : BookmarkItem, T>(
             }
 
             if (mManager.save()) {
-                Toast.makeText(mDialog.context, R.string.successful, Toast.LENGTH_SHORT).show()
+                val ctx = mDialog.context
+                Toast.makeText(ctx, R.string.successful, Toast.LENGTH_SHORT).show()
+                // Sync this bookmark to Firefox via PlacesBookmarksStorage
+                val savedItem = mItem ?: item
+                if (savedItem is com.prirai.android.nira.browser.bookmark.items.BookmarkSiteItem) {
+                    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+                        try {
+                            ctx.components.bookmarksStorage.addItem(
+                                "toolbar_____",
+                                savedItem.url,
+                                savedItem.title ?: savedItem.url,
+                                kotlin.UInt.MAX_VALUE
+                            )
+                        } catch (_: Exception) { }
+                    }
+                }
                 mOnClickListener?.onClick(mDialog, DialogInterface.BUTTON_POSITIVE)
                 mDialog.dismiss()
             } else {

--- a/app/src/main/java/com/prirai/android/nira/browser/sync/FxaSyncManager.kt
+++ b/app/src/main/java/com/prirai/android/nira/browser/sync/FxaSyncManager.kt
@@ -2,32 +2,41 @@ package com.prirai.android.nira.browser.sync
 
 import android.content.Context
 import android.os.Build
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import mozilla.appservices.fxaclient.FxaConfig
 import mozilla.appservices.fxaclient.FxaServer
+import mozilla.components.concept.sync.AccountEvent
+import mozilla.components.concept.sync.AccountEventsObserver
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceCommandIncoming
 import mozilla.components.concept.sync.DeviceConfig
 import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.FxaAuthData
 import mozilla.components.service.fxa.PeriodicSyncConfig
 import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.SyncConfig
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.concept.storage.BookmarkNodeType
+import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.service.fxa.sync.SyncReason
+import mozilla.components.service.fxa.toAuthType
 
 /**
  * Singleton wrapper around [FxaAccountManager].
@@ -38,9 +47,17 @@ class FxaSyncManager private constructor(private val context: Context) {
 
     companion object {
         const val CLIENT_ID = "a2270f727f45f648"
-        const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
+        const val REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel"
+        const val WEB_CHANNEL_MESSAGING_ID = "mozacWebchannel"
 
         @Volatile private var instance: FxaSyncManager? = null
+
+        /** The installed FxA WebChannel extension, set after successful installation. */
+        @Volatile var webChannelExtension: mozilla.components.concept.engine.webextension.WebExtension? = null
+
+        /** Debug info from the last finishAuthentication attempt. */
+        @Volatile var lastAuthDebugInfo: String? = null
+        @Volatile var lastAuthTimestamp: Long = 0L
 
         fun getInstance(context: Context): FxaSyncManager =
             instance ?: synchronized(this) {
@@ -49,6 +66,14 @@ class FxaSyncManager private constructor(private val context: Context) {
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    private val noOpLifecycleOwner = object : LifecycleOwner {
+        private val registry = LifecycleRegistry(this)
+        override val lifecycle: Lifecycle get() = registry
+        init {
+            registry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        }
+    }
 
     /** Exposed for use by [mozilla.components.feature.accounts.FxaWebChannelFeature]. */
     val serverConfig = FxaConfig(FxaServer.Release, CLIENT_ID, REDIRECT_URL)
@@ -71,6 +96,9 @@ class FxaSyncManager private constructor(private val context: Context) {
     private val _authSuccessEvent = MutableSharedFlow<String?>(extraBufferCapacity = 1)
     val authSuccessEvent: SharedFlow<String?> = _authSuccessEvent.asSharedFlow()
 
+    private val _incomingTabs = MutableSharedFlow<DeviceCommandIncoming.TabReceived>(extraBufferCapacity = 5)
+    val incomingTabs: SharedFlow<DeviceCommandIncoming.TabReceived> = _incomingTabs.asSharedFlow()
+
     val accountManager: FxaAccountManager by lazy {
         FxaAccountManager(
             context = context,
@@ -78,7 +106,8 @@ class FxaSyncManager private constructor(private val context: Context) {
             deviceConfig = DeviceConfig(
                 name = "Nira Browser on ${Build.MODEL}",
                 type = DeviceType.MOBILE,
-                capabilities = setOf(DeviceCapability.SEND_TAB)
+                capabilities = setOf(DeviceCapability.SEND_TAB),
+                secureStateAtRest = true,
             ),
             syncConfig = SyncConfig(
                 supportedEngines = setOf(SyncEngine.History, SyncEngine.Tabs, SyncEngine.Bookmarks),
@@ -87,40 +116,38 @@ class FxaSyncManager private constructor(private val context: Context) {
             applicationScopes = setOf("https://identity.mozilla.com/apps/oldsync")
         ).also { manager ->
             manager.register(accountObserver)
-            // Start the account manager as early as possible so WebChannel/OAuth completions
-            // are not dropped when the user opens Sync Settings before initialize() runs.
-            // Calling start() multiple times is safe — it is idempotent after the first call.
-            android.util.Log.d("FxaAuth", "accountManager lazy init: calling start()")
-            scope.launch {
-                try {
-                    manager.start()
-                    android.util.Log.d("FxaAuth", "accountManager.start() completed")
-                } catch (e: Exception) {
-                    android.util.Log.e("FxaAuth", "accountManager.start() failed: ${e.message}")
-                    android.util.Log.w("FxaSyncManager", "accountManager.start() failed: ${e.message}")
-                }
-            }
+            manager.registerForAccountEvents(accountEventsObserver, noOpLifecycleOwner, false)
+            // start() is called explicitly from BrowserApp.initializeAfterFirstFrame()
         }
     }
 
     private val accountObserver = object : AccountObserver {
+
+        override fun onReady(authenticatedAccount: OAuthAccount?) {
+            _isSignedIn.value = authenticatedAccount != null
+            if (authenticatedAccount != null) {
+                scope.launch {
+                    _accountEmail.value = accountManager.accountProfile()?.email
+                    // Auto-sync on restart so previously synced data is available
+                    triggerSync()
+                }
+            }
+        }
+
         override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
-            android.util.Log.d("FxaAuth", "onAuthenticated: authType=$authType")
-            android.util.Log.d("FxaSyncManager", "onAuthenticated: authType=$authType")
             _isSignedIn.value = true
             _syncError.value = null
             scope.launch {
-                val email = accountManager.accountProfile()?.email
-                android.util.Log.d("FxaAuth", "onAuthenticated: email=$email")
-                android.util.Log.d("FxaSyncManager", "onAuthenticated: email=$email")
-                _accountEmail.value = email
-                _authSuccessEvent.emit(email)
+                val profile = accountManager.accountProfile()
+                _accountEmail.value = profile?.email
+                _authSuccessEvent.emit(profile?.email)
+                // Trigger initial sync after successful authentication so data
+                // starts flowing immediately instead of waiting for manual "Sync Now".
+                triggerSync()
             }
         }
 
         override fun onLoggedOut() {
-            android.util.Log.d("FxaAuth", "logged out")
-            android.util.Log.d("FxaSyncManager", "onLoggedOut called")
             _isSignedIn.value = false
             _accountEmail.value = null
             _lastSyncTime.value = null
@@ -128,54 +155,40 @@ class FxaSyncManager private constructor(private val context: Context) {
         }
 
         override fun onProfileUpdated(profile: Profile) {
-            android.util.Log.d("FxaAuth", "onProfileUpdated: email=${profile.email}")
-            android.util.Log.d("FxaSyncManager", "onProfileUpdated: email=${profile.email}")
             _accountEmail.value = profile.email
         }
 
         override fun onAuthenticationProblems() {
-            android.util.Log.d("FxaAuth", "authentication problems")
-            android.util.Log.d("FxaSyncManager", "onAuthenticationProblems called")
             _isSignedIn.value = false
             _syncError.value = "Authentication problem — please sign in again."
         }
+    }
 
-        override fun onReady(authenticatedAccount: OAuthAccount?) {
-            android.util.Log.d("FxaAuth", "onReady: hasAccount=${authenticatedAccount != null}")
-            android.util.Log.d("FxaSyncManager", "onReady: authenticated=${authenticatedAccount != null}")
+    private val accountEventsObserver = object : AccountEventsObserver {
+        override fun onEvents(events: List<AccountEvent>) {
+            events.forEach {
+                when (it) {
+                    is AccountEvent.DeviceCommandIncoming -> {
+                        when (it.command) {
+                            is DeviceCommandIncoming.TabReceived -> {
+                                val cmd = it.command as DeviceCommandIncoming.TabReceived
+                                scope.launch { _incomingTabs.emit(cmd) }
+                            }
+                            is DeviceCommandIncoming.TabsClosed -> { /* ignore */ }
+                        }
+                    }
+                    else -> { /* ignore other event types */ }
+                }
+            }
         }
     }
 
-    /**
-     * Starts the account manager and restores any existing session.
-     * Must be called once during app startup (from a coroutine).
-     * Gracefully degrades if initialization fails.
-     */
-    suspend fun initialize() {
+    suspend fun start() {
         try {
-            android.util.Log.d("FxaAuth", "initialize(): calling accountManager.start()")
             accountManager.start()
-            android.util.Log.d("FxaAuth", "initialize(): accountManager.start() returned")
-            _isSignedIn.value = accountManager.authenticatedAccount() != null
-            if (_isSignedIn.value) {
-                _accountEmail.value = accountManager.accountProfile()?.email
-            }
+            android.util.Log.d("FxaAuth", "start() completed successfully")
         } catch (e: Exception) {
-            android.util.Log.e("FxaAuth", "initialize() failed: ${e.message}")
-            // Sync is unavailable but the app continues normally
-        }
-    }
-
-    suspend fun refreshAuthState() = withContext(Dispatchers.IO) {
-        try {
-            val account = accountManager.authenticatedAccount()
-            val isNowSignedIn = account != null
-            _isSignedIn.value = isNowSignedIn
-            if (isNowSignedIn) {
-                _accountEmail.value = accountManager.accountProfile()?.email
-            }
-        } catch (e: Exception) {
-            // ignore; state stays as-is
+            android.util.Log.e("FxaAuth", "start() failed: ${e.message}")
         }
     }
 
@@ -183,25 +196,123 @@ class FxaSyncManager private constructor(private val context: Context) {
         try {
             accountManager.logout()
         } catch (e: Exception) {
-            // Ignore sign-out errors
+            android.util.Log.e("FxaAuth", "signOut error: ${e.message}")
         }
     }
 
-    /** Triggers an immediate sync. Catches network errors and exposes them via [syncError]. */
+    suspend fun finishAuthentication(code: String, state: String, action: String?) {
+        val ts = System.currentTimeMillis()
+        try {
+            val authData = FxaAuthData(
+                authType = action.toAuthType(),
+                code = code,
+                state = state,
+            )
+            val result = accountManager.finishAuthentication(authData)
+            // Check account state RIGHT AFTER finishAuthentication returns
+            val hasAccountNow = accountManager.authenticatedAccount() != null
+            val emailNow = accountManager.accountProfile()?.email
+            lastAuthDebugInfo = "SUCCESS: result=$result immediate after: hasAccount=$hasAccountNow email=$emailNow (action=$action, code=${code.take(6)}..., state=${state.take(6)}...)"
+            lastAuthTimestamp = ts
+            android.util.Log.d("FxaAuth", "finishAuthentication returned $result, hasAccount=$hasAccountNow email=$emailNow")
+
+            // Re-check after a short delay to catch any tear-down
+            if (!hasAccountNow) {
+                kotlinx.coroutines.delay(2000)
+                val hasAccountDelayed = accountManager.authenticatedAccount() != null
+                val emailDelayed = accountManager.accountProfile()?.email
+                lastAuthDebugInfo += " | 2s later: hasAccount=$hasAccountDelayed email=$emailDelayed"
+                android.util.Log.d("FxaAuth", "2s later: hasAccount=$hasAccountDelayed email=$emailDelayed")
+            }
+        } catch (e: Exception) {
+            lastAuthDebugInfo = "ERROR: finishAuthentication threw ${e::class.simpleName}: ${e.message}"
+            lastAuthTimestamp = ts
+            android.util.Log.e("FxaAuth", "finishAuthentication failed: ${e.message}")
+            android.util.Log.e("FxaAuth", "stacktrace", e)
+        }
+    }
+
     suspend fun triggerSync() {
         try {
             _isSyncing.value = true
             _syncError.value = null
             accountManager.syncNow(reason = SyncReason.User)
+            accountManager.authenticatedAccount()?.deviceConstellation()?.pollForCommands()
             _lastSyncTime.value = System.currentTimeMillis()
         } catch (e: Exception) {
             _syncError.value = "Sync failed: ${e.message ?: "network error"}"
         } finally {
             _isSyncing.value = false
         }
+        // After sync completes, copy synced bookmarks into local bookmark manager
+        syncBookmarksToLocal()
     }
 
-    fun isSignedIn(): Boolean = accountManager.authenticatedAccount() != null
+    private suspend fun syncBookmarksToLocal() {
+        try {
+            val app = context as com.prirai.android.nira.BrowserApp
+            val placesStorage = app.components.bookmarksStorage
+            val localManager = com.prirai.android.nira.browser.bookmark.repository.BookmarkManager.getInstance(context)
+            
+            // Try root guid, then fall back to empty string
+            val tree = placesStorage.getTree("root________", true).getOrNull()
+                ?: placesStorage.getTree("", true).getOrNull()
+            if (tree == null) {
+                android.util.Log.d("FxaAuth", "syncBookmarksToLocal: tree is null, no bookmarks found")
+                return
+            }
+            android.util.Log.d("FxaAuth", "syncBookmarksToLocal: root title='${tree.title}' children=${tree.children?.size}")
+            
+            val children = tree.children ?: return
+            var added = 0
+            fun walkNodes(nodes: List<mozilla.components.concept.storage.BookmarkNode>) {
+                for (node in nodes) {
+                    when (node.type) {
+                        BookmarkNodeType.FOLDER -> {
+                            node.children?.let { walkNodes(it) }
+                        }
+                        BookmarkNodeType.ITEM -> {
+                            val url = node.url ?: continue
+                            val title = node.title ?: url
+                            if (!localManager.isBookmarked(url)) {
+                                localManager.add(localManager.root,
+                                    com.prirai.android.nira.browser.bookmark.items.BookmarkSiteItem(
+                                        title, url, System.currentTimeMillis()
+                                    )
+                                )
+                                added++
+                            }
+                        }
+                        BookmarkNodeType.SEPARATOR -> { }
+                    }
+                }
+            }
+            walkNodes(children)
+            
+            if (added > 0) {
+                localManager.save()
+                android.util.Log.d("FxaAuth", "syncBookmarksToLocal: added $added bookmarks")
+            } else {
+                android.util.Log.d("FxaAuth", "syncBookmarksToLocal: no new bookmarks to add (${countBookmarks(tree)} total in sync)")
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("FxaAuth", "syncBookmarksToLocal error: ${e.message}")
+            android.util.Log.e("FxaAuth", "syncBookmarksToLocal stack:", e)
+        }
+    }
+
+    private fun countBookmarks(node: mozilla.components.concept.storage.BookmarkNode): Int {
+        var count = 0
+        if (node.type == BookmarkNodeType.ITEM) count++
+        node.children?.forEach { count += countBookmarks(it) }
+        return count
+    }
+
+        fun isSignedIn(): Boolean = accountManager.authenticatedAccount() != null
 
     fun getAccountEmail(): String? = accountManager.accountProfile()?.email
+
+    fun close() {
+        accountManager.close()
+    }
 }

--- a/app/src/main/java/com/prirai/android/nira/browser/sync/FxaSyncManager.kt
+++ b/app/src/main/java/com/prirai/android/nira/browser/sync/FxaSyncManager.kt
@@ -308,7 +308,7 @@ class FxaSyncManager private constructor(private val context: Context) {
         return count
     }
 
-        fun isSignedIn(): Boolean = accountManager.authenticatedAccount() != null
+    fun isSignedIn(): Boolean = accountManager.authenticatedAccount() != null
 
     fun getAccountEmail(): String? = accountManager.accountProfile()?.email
 

--- a/app/src/main/java/com/prirai/android/nira/settings/fragment/SyncSettingsFragment.kt
+++ b/app/src/main/java/com/prirai/android/nira/settings/fragment/SyncSettingsFragment.kt
@@ -64,8 +64,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.prirai.android.nira.BrowserActivity
 import com.prirai.android.nira.ext.components
@@ -125,17 +123,6 @@ class SyncSettingsFragment : Fragment() {
                     var deviceCount by remember { mutableStateOf<Int?>(null) }
 
                     val lifecycleOwner = LocalLifecycleOwner.current
-
-                    // Refresh auth state on resume
-                    DisposableEffect(lifecycleOwner) {
-                        val observer = LifecycleEventObserver { _, event ->
-                            if (event == Lifecycle.Event.ON_RESUME) {
-                                coroutineScope.launch { syncManager.refreshAuthState() }
-                            }
-                        }
-                        lifecycleOwner.lifecycle.addObserver(observer)
-                        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-                    }
 
                     // Show toast on successful sign-in
                     LaunchedEffect(Unit) {
@@ -218,6 +205,7 @@ class SyncSettingsFragment : Fragment() {
                         syncBookmarksEnabled = syncBookmarksEnabled,
                         onSignIn = {
                             isSigningIn = true
+                            android.util.Log.d("FxaAuth", "Sign in button pressed, calling beginAuthentication")
                             requireContext().components.fxaAuthFeature
                                 .beginAuthentication(requireContext(), settingsEntryPoint)
                         },
@@ -240,6 +228,56 @@ class SyncSettingsFragment : Fragment() {
                                     }
                                 } catch (_: Exception) { }
                             }
+                        },
+                        onExportLogs = {
+                            val syncInfo = StringBuilder()
+                            syncInfo.appendLine("=== Nira Sync Diagnostics ===")
+                            syncInfo.appendLine("App: Nira 0.5.5 (debug)")
+                            syncInfo.appendLine("Time: ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date())}")
+                            syncInfo.appendLine()
+                            syncInfo.appendLine("--- Sync State ---")
+                            syncInfo.appendLine("isSignedIn: $isSignedIn")
+                            syncInfo.appendLine("accountEmail: ${accountEmail ?: "null"}")
+                            syncInfo.appendLine("isSyncing: $effectiveIsSyncing")
+                            val lastSyncStr = effectiveLastSyncTime?.let {
+                                java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date(it))
+                            } ?: "never"
+                            syncInfo.appendLine("lastSyncTime: $lastSyncStr")
+                            syncInfo.appendLine("syncError: ${syncError ?: "none"}")
+                            syncInfo.appendLine()
+                            syncInfo.appendLine("--- Account Manager ---")
+                            val am = syncManager.accountManager
+                            syncInfo.appendLine("accountManager.authenticatedAccount: ${am.authenticatedAccount() != null}")
+                            val profile = am.accountProfile()
+                            syncInfo.appendLine("profile email: ${profile?.email ?: "null"}")
+                            syncInfo.appendLine("profile avatar: ${profile?.avatar ?: "null"}")
+                            syncInfo.appendLine()
+                            syncInfo.appendLine("--- Last Auth Attempt ---")
+                            val lastDebug = com.prirai.android.nira.browser.sync.FxaSyncManager.lastAuthDebugInfo
+                            val lastTs = com.prirai.android.nira.browser.sync.FxaSyncManager.lastAuthTimestamp
+                            syncInfo.appendLine("lastAuthDebugInfo: ${lastDebug ?: "none (no attempt recorded)"}")
+                            if (lastTs > 0) {
+                                val lastTsStr = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date(lastTs))
+                                syncInfo.appendLine("lastAuthTimestamp: $lastTsStr")
+                            }
+                            syncInfo.appendLine()
+                            syncInfo.appendLine("--- WebChannel Extension ---")
+                            val ext = com.prirai.android.nira.browser.sync.FxaSyncManager.webChannelExtension
+                            syncInfo.appendLine("webChannelExtension: ${if (ext != null) "installed (${ext.id})" else "NOT INSTALLED"}")
+                            syncInfo.appendLine()
+                            syncInfo.appendLine("--- Device ---")
+                            syncInfo.appendLine("model: ${android.os.Build.MODEL}")
+                            syncInfo.appendLine("brand: ${android.os.Build.BRAND}")
+                            syncInfo.appendLine("sdk: ${android.os.Build.VERSION.SDK_INT}")
+                            val text = syncInfo.toString()
+                            android.util.Log.d("FxaAuth", "Exporting diagnostics:\n$text")
+                            val sendIntent = android.content.Intent().apply {
+                                action = android.content.Intent.ACTION_SEND
+                                putExtra(android.content.Intent.EXTRA_TEXT, text)
+                                type = "text/plain"
+                            }
+                            val shareIntent = android.content.Intent.createChooser(sendIntent, "Share Sync Diagnostics")
+                            context.startActivity(shareIntent)
                         },
                         onEngineToggle = { engine, enabled ->
                             when (engine) {
@@ -287,6 +325,7 @@ private fun SyncSettingsScreen(
     onSignOut: () -> Unit,
     onSyncNow: () -> Unit,
     onManageAccount: () -> Unit,
+    onExportLogs: () -> Unit,
     onEngineToggle: (SyncEngine, Boolean) -> Unit
 ) {
     Scaffold { innerPadding ->
@@ -333,6 +372,19 @@ private fun SyncSettingsScreen(
                 syncBookmarksEnabled = syncBookmarksEnabled,
                 onEngineToggle = onEngineToggle
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Diagnostics / export logs button
+            OutlinedButton(
+                onClick = onExportLogs,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text("📋 Export Diagnostics")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes FxA sign-in where `finishAuthentication()` returned `true` but `authenticatedAccount()` stayed `null` — bookmarks now sync bidirectionally between Firefox and Nira.

Closes #79

## Root Cause
The redirect URL was using an HTTP URL (`https://accounts.firefox.com/oauth/success/...`) instead of the WebChannel OOB URN (`urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel`). This caused FxA to deliver the OAuth code via HTTP redirect instead of WebChannel, leading to silent authentication-side-effect failures.

## Changes (5 files, surgically applied on upstream main)
| File | Change |
|------|--------|
| `FxaSyncManager.kt` | REDIRECT_URL → WebChannel OOB URN; `syncBookmarksToLocal()` bridge; `finishAuthentication()` with debug tracking; incoming tabs collection; `AccountEventsObserver` for device commands |
| `BrowserApp.kt` | NSS library loading + `AppServicesInitializer.init()` + `RustHttpConfig.setClient()` for Rust HTTP; installs `fxa@mozac.org` WebChannel extension; `start()` with incoming tabs collection — *no LocaleAwareApplication or other unrelated changes* |
| `SyncSettingsFragment.kt` | "Export Diagnostics" button with full sync state (account, device, extension status, last auth debug info) |
| `AddBookmarkDialog.kt` | Local bookmarks also save to `PlacesBookmarksStorage` for sync |
| `build.gradle` | Added `lib-dataprotect` and `support-appservices` deps |

**Note:** AppRequestInterceptor.kt and BaseBrowserFragment.kt are intentionally unchanged — upstream already has `FxaWebChannelFeature` and never had `handleFxaRedirect()`.